### PR TITLE
Add support for path containing spaces

### DIFF
--- a/lib/lilypond.coffee
+++ b/lib/lilypond.coffee
@@ -43,7 +43,7 @@ module.exports =
 
       unless @config.useCustomArgumentsOnly
         args.push "-f#{@config.fileType}"
-        args.push "-o #{@determineOutputLocation path.dirname filePath}"
+        args.push "-o \"#{@determineOutputLocation path.dirname filePath}\""
 
         switch @config.fileType
           when 'pdf'
@@ -53,7 +53,7 @@ module.exports =
               args.push '-dpixmap-format=pngalpha'
 
       args.push @config.customArguments
-      args.push filePath
+      args.push "\"#{filePath}\""
 
       return args
 


### PR DESCRIPTION
A small improvement to add support for path containing spaces. As I have absolutely no idea about coffeescript, I simply added double quotes around input and output paths but there is certainly a more elegant way to it.

Btw, thank you for this really nice plugin !