### PR TITLE
Update keymap to work with AtLilyPond 1.2.1

### DIFF
--- a/keymaps/lilycompile.cson
+++ b/keymaps/lilycompile.cson
@@ -1,2 +1,2 @@
-'[data-grammar="source AtLilyPond"]':
+'[data-grammar="source lilypond"]':
   'ctrl-alt-l': 'lilycompile:compile'


### PR DESCRIPTION
AtLilyPond 1.2.1 has changed its scope name to `source.lilypond`, so we need an update to keep the keybinding working.