### PR TITLE
Add compileAfterSave option

### DIFF
--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -23,6 +23,11 @@ module.exports =
     or only shown.'
     type: 'boolean'
     default: true
+  compileAfterSave:
+    title: 'Compile Lilypond after saving'
+    description: 'Run `lilycompile:compile` after saving a `.ly` file.'
+    type: 'boolean'
+    default: true
   outputPath:
     description: 'This is where the generated files are placed.
     Relative to the directory where the .ly file is located.'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -15,6 +15,13 @@ module.exports =
 
     @registerCommands()
 
+    @subscriptions.add atom.workspace.observeTextEditors (editor) =>
+      @subscriptions.add editor.onDidSave () =>
+        if atom.config.get('lilycompile.compileAfterSave') and \
+            editor.buffer.file?.path
+          if @controller.isLilypondFile(editor.buffer.file?.path)
+            @controller.compile()
+
   deactivate: ->
     @subscriptions.dispose()
     @controller.deactivate()

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "keywords": [
     "lilypond"
   ],
-  "activationCommands": {
-    "atom-workspace": "lilycompile:compile"
-  },
   "repository": "https://github.com/AljoschaMeyer/atom-lilycompile",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
This resolves #6, but I couldn't figure out a perfect way to just always compile after saving without requiring the user to manually run `lilycompile:compile` first to activate the package. I ended up removing `activationCommands` so it now activates on startup, which adds a little time but not much.