### PR TITLE
compile service provided

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -37,3 +37,8 @@ module.exports =
   registerCommands: ->
     @subscriptions.add atom.commands.add 'atom-workspace'
     , 'lilycompile:compile': => @controller.compile()
+
+  provideCompile: ->
+    Controller ?= require './controller'
+    @controller = new Controller
+    return @controller

--- a/package.json
+++ b/package.json
@@ -11,6 +11,16 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
+
+    "providedServices": {
+      "lilycompile": {
+        "description": "renders editor's filepath from .ly to .pdf file in new editor pane",
+        "versions": {
+          "0.7.0": "provideCompile"
+        }
+      }
+    },
+
   "dependencies": {
     "mkdirp": "^0.5.1"
   }


### PR DESCRIPTION
Guten Tag, Aljoscha,

Vielen Dank für lilycompile. Es sieht wunderschön aus. Ich schreibe ein Package für Atom das integriert die Abjad API für algorithmische Komposition, und dafür muss ich seine `Controller.compile()` Funktion exponieren, um sie zu benutzen in meine einzige Package. Sie werden meine Entwicklungen einfach sehen: ich habe nur eine neue Funktion in main.coffee geschrieben -- `provideCompile` heißt sie -- und auch einen neuen Teil in `package.json` für `providedServices` dazugegeben.

mit freundlichen Grüßen aus Kalifornien, 
Jeffrey

Hi Aljoscha,

Thank you for lilycompile. It looks wonderful. I'm writing a package for Atom that integrates the Abjad API for algorithmic composition, and I need lilycompile to provide your `Controller.compile()` function as a service, so that I can call lilycompile code from within my code. To this end, you'll see a new function in `main.coffee` -- named `provideCompile` -- and also a new part of `package.json` for `providedServices`.

cheers from California,
Jeffrey