### PR TITLE
added optional path argument to controller.compile

### DIFF
--- a/lib/controller.coffee
+++ b/lib/controller.coffee
@@ -7,20 +7,27 @@ module.exports =
       @lily = new Lilypond
       @fileOpener = new Opener
 
-    compile: ->
-      editorDetails = @getEditorDetails()
+    empty_path = null
+    compile: (path = empty_path) ->
 
-      unless editorDetails.filePath?
-        atom.notifications.addError 'Can only compile .ly files.', dismissable: true
-        return
+      if path
+        compilePath = path
+      else
+        editorDetails = @getEditorDetails()
 
-      unless @isLilypondFile editorDetails.filePath
-        atom.notifications.addError 'Can only compile .ly files.', dismissable: true
-        return
+        unless editorDetails.filePath?
+          atom.notifications.addError 'Can only compile .ly files.', dismissable: true
+          return
 
-      editorDetails.editor.save() if editorDetails.editor.isModified()
+        unless @isLilypondFile editorDetails.filePath
+          atom.notifications.addError 'Can only compile .ly files.', dismissable: true
+          return
 
-      @lily.compile editorDetails.filePath
+        editorDetails.editor.save() if editorDetails.editor.isModified()
+
+        compilePath = editorDetails.filePath
+
+      @lily.compile compilePath
       .then (result) =>
         @fileOpener.open(result)
         return Promise.resolve()


### PR DESCRIPTION
I realized that my code will almost certainly need to provide a path directly to `controller.compile`, rather than depend on the current active text editor for this information, as in the previous release. 

To this end, I've added an optional `path` argument to `controller.compile` that defaults to `null` when not supplied, which preserves the previous functionality. 

Please have a look, tweak, advise, at your earliest convenience.